### PR TITLE
Temporarily disable upload to archives.jenkins-ci.org

### DIFF
--- a/sync.sh
+++ b/sync.sh
@@ -46,7 +46,9 @@ pushd ${UPDATES_DIR}
 popd
 
 echo ">> Delivering bits to fallback"
-/srv/releases/populate-archives.sh
+# Temporarily disabled while archives.jenkins-ci.org is offline
+# /srv/releases/populate-archives.sh
+# Enable when archives.jenkins-ci.org is online
 /srv/releases/batch-upload.bash || true
 
 echo ">> Updating the latest symlink for weekly"


### PR DESCRIPTION
## Do not upload to archive.jenkins.io

Server is down and cannot receive the files.

See https://github.com/jenkins-infra/mirror-scripts/pull/5 for an example and https://github.com/jenkins-infra/mirror-scripts/pull/6 for the change that reverted it when archives.jenkins.io was again available.
