### PR TITLE
sync-recent-releases must copy directory content

### DIFF
--- a/sync-recent-releases.sh
+++ b/sync-recent-releases.sh
@@ -31,7 +31,7 @@ while IFS= read -r release; do
      blobxfer upload --storage-account "$AZURE_STORAGE_ACCOUNT" --storage-account-key "$AZURE_STORAGE_KEY" --local-path "${BASE_DIR}/plugins/$release" --remote-path mirrorbits/plugins/${release} --recursive --mode file --no-overwrite --exclude 'mvn%20org.apache.maven.plugins:maven-release-plugin:2.5:perform' --file-md5 --skip-on-md5-match  --no-progress-bar
      ssh -n ${HOST} "mkdir -p jenkins/plugins/${release}"
 
-     rsync -avz ${BASE_DIR}/plugins/${release} ${HOST}:jenkins/plugins/${release}
+     rsync -avz ${BASE_DIR}/plugins/${release}/ ${HOST}:jenkins/plugins/${release}
      echo $(date +%s) > ${BASE_DIR}/TIME
      rsync -avz ${BASE_DIR}/TIME ${HOST}:jenkins/TIME
      echo "Done uploading $release"


### PR DESCRIPTION
This change prevents the script `sync-recent-release.sh` to push new `.hpi` in the correct location which should be [plugins/electricflow/1.1.22](https://ftp-nyc.osuosl.org/pub/jenkins/plugins/electricflow/1.1.22) instead of [/plugins/electricflow/1.1.22/1.1.22](https://ftp-nyc.osuosl.org/pub/jenkins/plugins/electricflow/1.1.22/1.1.22)

Because new files were in the wrong location, Mirrorbits could not calculate the correct file hashes so we had to wait for the sync.sh script which runs once per hour to force a Rsync from pkg.origin.jenkins.io to OSUOSL mirrors. Then only Mirrorbits could calculate the correct files hashes.
Because third mirrors often use OSUOSL mirrors as the reference, it delayed the propagation of the files on those third mirrors as well.

This explains why it took so long (several hours) to redirect traffic to mirrors.

get.jenkins.io is currently configured to fallback 404 requests to archives.jenkins.io or fallback.get.jenkins.io.
sync-recent-release does not publish `*.hpi` to archives.jenkins.io so requests arriving there just return errors which in some cases generate a re-try to get.jenkins.io. Only fallback.get.jenkins.io could correctly return the correct hpi file.
Because fallback.get.jenkins.io shares the same Azure file storage than get.jenkins.io if too many connections arrives to fallback.get.jenkins.io then it exausts the  number of open file handle.