### PR TITLE
fix(batch upload,sync) follow up of 503b7ac to use a virtual env for blobxfer CLI

### DIFF
--- a/batch-upload.bash
+++ b/batch-upload.bash
@@ -1,9 +1,10 @@
 #!/bin/bash
 
+source /srv/releases/.venv-blobxfer/bin/activate
 source /srv/releases/.azure-storage-env
 
 ## Sync files from "/srv/releases/jenkins/$CONTAINER" to $CONTAINER for each container in "$AZURE_STORAGE_ACCOUNT",
-for CONTAINER in $(az storage container list --account-name "$AZURE_STORAGE_ACCOUNT" --account-key "$AZURE_STORAGE_KEY" --query '[*].name' --output table ); do 
+for CONTAINER in $(az storage container list --account-name "$AZURE_STORAGE_ACCOUNT" --account-key "$AZURE_STORAGE_KEY" --query '[*].name' --output table ); do
 	if [ -d "/srv/releases/jenkins/$CONTAINER" ]; then
 		echo "Syncing Container: $CONTAINER";
 

--- a/sync.sh
+++ b/sync.sh
@@ -71,7 +71,7 @@ echo ">> move index from staging to production"
 if [ "${FLAG}" = '--full-sync' ]; then
   echo ">> Update artifacts on get.jenkins.io"
   source /srv/releases/.azure-storage-env
+  source /srv/releases/.venv-blobxfer/bin/activate
   /usr/local/bin/blobxfer upload --storage-account "$AZURE_STORAGE_ACCOUNT" --storage-account-key "$AZURE_STORAGE_KEY" --local-path "$BASE_DIR" --remote-path mirrorbits --recursive --mode file --file-md5  --skip-on-md5-match --progress-bar --include "*.json" 2>&1
   time /usr/local/bin/blobxfer upload --storage-account "$AZURE_STORAGE_ACCOUNT" --storage-account-key "$AZURE_STORAGE_KEY" --local-path "$BASE_DIR" --remote-path mirrorbits --recursive --mode file --no-overwrite --exclude 'mvn%20org.apache.maven.plugins:maven-release-plugin:2.5:perform' --transfer-threads 128  --no-progress-bar 2>&1
 fi
-


### PR DESCRIPTION
This PR follows up #10 (ref. https://github.com/jenkins-infra/helpdesk/issues/3411).

It ensures that blobxfer is always executed after loading the virutal env where it was installed.

(note: for the sake of knowledge sharing, please note that this PR, once merged, will require a manual deployment by running the command `git pull origin master` from the directory `/srv/releases` on the VM `pkg.origin.jenkins.io`)