### PR TITLE
[sync-recent-releases.sh] Populate archives.jenkins.io as mirror fallback

### DIFF
--- a/sync-recent-releases.sh
+++ b/sync-recent-releases.sh
@@ -40,4 +40,8 @@ while IFS= read -r release; do
     echo "Done uploading $release"
 done <<< "${RECENT_RELEASES}"
 
+echo ">> Delivering bits to fallback"
+/srv/releases/populate-archives.sh
+
+echo ">> Telling OSUUSL to gets the new bits"
 ssh jenkins@ftp-osl.osuosl.org 'sh trigger-jenkins'

--- a/sync-recent-releases.sh
+++ b/sync-recent-releases.sh
@@ -40,7 +40,7 @@ while IFS= read -r release; do
     echo "Done uploading $release"
 done <<< "${RECENT_RELEASES}"
 
-echo ">> Telling OSUUSL to gets the new bits"
+echo ">> Telling OSUOSL to gets the new bits"
 ssh jenkins@ftp-osl.osuosl.org 'sh trigger-jenkins'
 
 echo ">> Delivering bits to fallback from OSUOSL"

--- a/sync-recent-releases.sh
+++ b/sync-recent-releases.sh
@@ -40,8 +40,8 @@ while IFS= read -r release; do
     echo "Done uploading $release"
 done <<< "${RECENT_RELEASES}"
 
-echo ">> Delivering bits to fallback"
-/srv/releases/populate-archives.sh
-
 echo ">> Telling OSUUSL to gets the new bits"
 ssh jenkins@ftp-osl.osuosl.org 'sh trigger-jenkins'
+
+echo ">> Delivering bits to fallback from OSUOSL"
+/srv/releases/populate-archives.sh

--- a/sync-recent-releases.sh
+++ b/sync-recent-releases.sh
@@ -43,5 +43,5 @@ done <<< "${RECENT_RELEASES}"
 echo ">> Telling OSUOSL to gets the new bits"
 ssh jenkins@ftp-osl.osuosl.org 'sh trigger-jenkins'
 
-echo ">> Delivering bits to fallback from OSUOSL"
+echo ">> Delivering bits to mirrors fallback (archives.jenkins.io) from OSUOSL"
 /srv/releases/populate-archives.sh


### PR DESCRIPTION
As per https://github.com/jenkins-infra/helpdesk/issues/3828#issuecomment-1881011001, the download mirror fallback system was changed to use archives.jenkins.io.

This creates cases when, during a few minutes, a given file is advertised in the mirror system (because already copied by blobxfer) but not yet available in archives.jenkins.io. This is a blocker for security advisories.

This PR is a quick fix to ensure the blocker is removed: it ensures that the scripts syncs archives.jenkins.io once the bits are delivered on OSUOSL. It must be run as second because the source is OSUOSL.

The impact on the execution time varies from 25s to 2m20 based on our history: this will be greatly optimized in the future with 2 mains elements:
- https://github.com/jenkins-infra/helpdesk/issues/3414 => will improve the blobxfer copy time by using azcopy
- https://github.com/jenkins-infra/helpdesk/issues/2649 =>should help us to parallelize copies to different locations. Using it here to ensure archives.jenkins.io is populated from pkg is way better.