### PR TITLE
fix: cleanup .azcopy folder

### DIFF
--- a/sync.sh
+++ b/sync.sh
@@ -107,6 +107,6 @@ fi
 # Remove completed azcopy plans
 azcopy jobs clean --with-status=completed
 # Remove uncompleted azcopy plans older than 30 days
-find /srv/releases/.azcopy/plans -type f -mtime +30 -delete
+find "${HOME}"/.azcopy/plans -type f -mtime +30 -delete
 # Remove azcopy logs older than 30 days
-find /srv/releases/.azcopy -type f -name '*.log' -mtime +30 -delete
+find "${HOME}"/.azcopy -type f -name '*.log' -mtime +30 -delete

--- a/sync.sh
+++ b/sync.sh
@@ -103,3 +103,10 @@ if [[ "${FLAG}" = '--full-sync' ]]; then
     --exclude-pattern='*.json' \
     "${BASE_DIR}" "${fileShareSignedUrl}"
 fi
+
+# Remove completed azcopy plans
+azcopy jobs clean --with-status=completed
+# Remove uncompleted azcopy plans older than 30 days
+find /srv/releases/.azcopy/plans -type f -mtime +30 -delete
+# Remove azcopy logs older than 30 days
+find /srv/releases/.azcopy -type f -name '*.log' -mtime +30 -delete


### PR DESCRIPTION
This PR cleans .azcopy folder at the end of each sync.sh call, pruning completed plans and removing incomplete plans & logs older than 30 days so this folder doesn't increase infinitely.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3414#issuecomment-2019633963 