### PR TITLE
hotfix(sync.sh) use time based comparison for azcopy (performance baseline)

### DIFF
--- a/sync.sh
+++ b/sync.sh
@@ -89,8 +89,7 @@ if [[ "${FLAG}" = '--full-sync' ]]; then
     --skip-version-check \
     --recursive=true \
     --delete-destination=false \
-    --compare-hash=MD5 \
-    --put-md5 \
+    --log-error=ERROR \
     --include-pattern='*.json' \
     "${BASE_DIR}" "${fileShareSignedUrl}"
 
@@ -98,8 +97,7 @@ if [[ "${FLAG}" = '--full-sync' ]]; then
     --skip-version-check \
     --recursive=true \
     --delete-destination=false \
-    --compare-hash=MD5 \
-    --put-md5 \
+    --log-error=ERROR \
     --exclude-pattern='*.json' \
     "${BASE_DIR}" "${fileShareSignedUrl}"
 fi


### PR DESCRIPTION
The current MD5 based check (using xattr) is really really slow and we have a hard time finishing the initial.

Before going forward and exploring the next runs (after initial MD5 calculation), this PR starts using time based comparison to establish a performance baseline for `azcopy`.


Note: we also add the flag `--log-error` to decrease the IO (scanning logs are quite verbose). #19 took care of the scanning logs cleanup (distinct topic).