### PR TITLE
fix: azcopy sync all versions of recently released plugins

### DIFF
--- a/sync-recent-releases.sh
+++ b/sync-recent-releases.sh
@@ -47,12 +47,12 @@ while IFS= read -r release; do
     # Don't print any trace
     set +x
 
-    # ${release} is a directory (hence the trailing slash for destination) to avoid `azcopy` error related to file <-> dir
+    # Synchronising all releases of the plugin as azcopy sync only the file instead of the folder if ${release} is passed as it is
     azcopy sync \
         --skip-version-check \
         --recursive=true \
         --delete-destination=false \
-        "${BASE_DIR}/plugins/${release}" "${urlWithoutToken}plugins/?${token}"
+        "${BASE_DIR}/plugins/$(dirname "${release}")" "${urlWithoutToken}plugins/?${token}"
 
     # Following commands traces are safe
     set -x


### PR DESCRIPTION
This PR syncs with azcopy all versions of any plugin with a recent release to avoid azcopy copying only the plugin file to the destination instead of the release folder.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/4013
- https://github.com/jenkins-infra/helpdesk/issues/3414