### PR TITLE
fix(sync*) use azcopy copy instead of azcopy sync

### DIFF
--- a/sync-recent-releases.sh
+++ b/sync-recent-releases.sh
@@ -71,6 +71,5 @@ set -x
 echo ">> Telling OSUOSL to gets the new bits"
 ssh jenkins@ftp-osl.osuosl.org 'sh trigger-jenkins'
 
-## Commented out until OSUOSL <-> archives permissions are fixed
-# echo ">> Delivering bits to mirrors fallback (archives.jenkins.io) from OSUOSL"
-# /srv/releases/populate-archives.sh
+echo ">> Delivering bits to mirrors fallback (archives.jenkins.io) from OSUOSL"
+/srv/releases/populate-archives.sh

--- a/sync-recent-releases.sh
+++ b/sync-recent-releases.sh
@@ -41,18 +41,18 @@ while IFS= read -r release; do
     find "${BASE_DIR}/plugins/${release}" -exec chown mirrorbrain:www-data {} \;
     find "${BASE_DIR}/plugins/${release}" -type f -exec chmod 644 {} \;
     find "${BASE_DIR}/plugins/${release}" -type d -exec chmod 755 {} \;
-    
+
     echo "Uploading ${release}"
 
     # Don't print any trace
     set +x
 
-    # ${release} is a directory (hence the trailing slash for destination) to avoid `azcopy` error related to file <-> dir
-    azcopy sync \
-        --skip-version-check \
-        --recursive=true \
-        --delete-destination=false \
-        "${BASE_DIR}/plugins/${release}" "${urlWithoutToken}plugins/?${token}"
+    azcopy copy \
+        --skip-version-check `# Do not check for new azcopy versions (we have updatecli + puppet for this)` \
+        --recursive `# Source directory contains at least one subdirectory` \
+        --overwrite=ifSourceNewer `# Only overwrite if source is more recent (time comparison)` \
+        --log-level=ERROR `# Do not write too much logs (I/O...)` \
+        "${BASE_DIR}/plugins/${release}/*" "${urlWithoutToken}plugins/${release}?${token}"
 
     # Following commands traces are safe
     set -x

--- a/sync.sh
+++ b/sync.sh
@@ -93,7 +93,7 @@ if [[ "${FLAG}" = '--full-sync' ]]; then
     --overwrite=ifSourceNewer `# Only overwrite if source is more recent (time comparison)` \
     --log-level=ERROR `# Do not write too much logs (I/O...)` \
     --include-pattern='*.json' `# First quick pass on the update center JSON files` \
-    "${BASE_DIR}" "${fileShareSignedUrl}"
+    "${BASE_DIR}/*" "${fileShareSignedUrl}"
 
   azcopy copy --dry-run \
     --skip-version-check `# Do not check for new azcopy versions (we have updatecli + puppet for this)` \
@@ -101,7 +101,7 @@ if [[ "${FLAG}" = '--full-sync' ]]; then
     --overwrite=ifSourceNewer `# Only overwrite if source is more recent (time comparison)` \
     --log-level=ERROR `# Do not write too much logs (I/O...)` \
     --exclude-pattern='*.json' `# Second pass with all files except update center JSON files` \
-    "${BASE_DIR}" "${fileShareSignedUrl}"
+    "${BASE_DIR}/*" "${fileShareSignedUrl}"
 
   # Remove completed azcopy plans
   azcopy jobs clean --with-status=completed

--- a/sync.sh
+++ b/sync.sh
@@ -87,7 +87,7 @@ if [[ "${FLAG}" = '--full-sync' ]]; then
 
   fileShareSignedUrl=$(get-fileshare-signed-url.sh)
 
-  azcopy copy --dry-run \
+  azcopy copy \
     --skip-version-check `# Do not check for new azcopy versions (we have updatecli + puppet for this)` \
     --recursive `# Source directory contains at least one subdirectory` \
     --overwrite=ifSourceNewer `# Only overwrite if source is more recent (time comparison)` \
@@ -95,7 +95,7 @@ if [[ "${FLAG}" = '--full-sync' ]]; then
     --include-pattern='*.json' `# First quick pass on the update center JSON files` \
     "${BASE_DIR}/*" "${fileShareSignedUrl}"
 
-  azcopy copy --dry-run \
+  azcopy copy \
     --skip-version-check `# Do not check for new azcopy versions (we have updatecli + puppet for this)` \
     --recursive `# Source directory contains at least one subdirectory` \
     --overwrite=ifSourceNewer `# Only overwrite if source is more recent (time comparison)` \


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3414#issuecomment-2019633963

This PR introduces the following changes:

- Use `azcopy copy` instead of `azcopy sync` for improved performances
    -  For `sync-recent-releases.sh` (run every 5 min. by jenkins-infra/update-center2), which involves copying new plugin directory tree for each new released plugin, `azcopy sync` failed since it [replaced `blobxfer`](#15) because it could not create the directory hierachy. Using the `copy` make sense in any cases because we want to only copy the subset with no partial/differential copy.
        -  Note: the performance improvement is huge on our manual tests: we went from 5m15/5m30 to 4m/4m20 (and less than 3m30 if no plugins to copy).
  - For `sync.sh`, we enable the overwrite of files only if the source file is newer than the destination.
      - The recursive directory creation is done with success, but the scanning log shows an HTTP/404 response before creation , even in "ERROR" log (FWIW). But it is NOT an error for the copy process.
      - Note: performance improvement is also huge here: `sync.sh --full-sync` takes less than 2 min end to end.
- Disable the `batch-upload.sh` script for `sync.sh` as this script always fail and slows down the whole process
- Move the `azcopy` cleanup to only run when `azcopy` commands are executed (e.g. when called with the `--full-sync` flag). It avoids putting the Core releases at risk as no azcopy is involved in these cases.
- Enable again the population of archive as part of the update-center2